### PR TITLE
Use CR/LF for logging

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -72,7 +72,7 @@ func main() {
 
 func LogForDebug(message string) {
 	DebugLogs = append(DebugLogs, message)
-	log.Print(message)
+	log.Print(message + "\r\n")
 }
 
 type LaunchResponse struct {


### PR DESCRIPTION
It is better to use CR/LF on windows.