### PR TITLE
Fix "the context menu item is blank" issue

### DIFF
--- a/background.js
+++ b/background.js
@@ -2,13 +2,13 @@ function installMenuItems() {
   browser.contextMenus.create({
     id: 'page',
     type: 'normal',
-    title: browser.i18n.getMessage('contextMenu.page.label'),
+    title: browser.i18n.getMessage('contextMenu_page_label'),
     contexts: installMenuItems.supportsTabContext ? ['page', 'tab'] : ['page']
   });
   browser.contextMenus.create({
     id: 'link',
     type: 'normal',
-    title: browser.i18n.getMessage('contextMenu.link.label'),
+    title: browser.i18n.getMessage('contextMenu_link_label'),
     contexts: ['link']
   });
 }


### PR DESCRIPTION
### What's the problem?

What used to happen is that initialMenuItems() tries to retrieve
localized strings using wrong key names. This results in odd menu
items which have empty title strings.

### Screenshot

Here is what the menus look like in the master branch:

![2018-07-10-151056_227x302_scrot](https://user-images.githubusercontent.com/8974561/42492286-7cd4ef8e-8453-11e8-88a8-b55de49b7d90.png)