### PR TITLE
Add "BrowserSelector" support

### DIFF
--- a/common/common.js
+++ b/common/common.js
@@ -36,5 +36,6 @@ configs = new Configs({
 	logging           : true,
 	logRotationCount  : 12,
 	logRotationTime   : 24,
+	useBrowserSelector: false,
 	debug             : false
 });

--- a/managed-storage/ieview-we@clear-code.com.json
+++ b/managed-storage/ieview-we@clear-code.com.json
@@ -3,15 +3,16 @@
   "description": "Managed Storage for IE View WE",
   "type": "storage",
   "data": {
-    "forceielist"      : "http://www.example.com/*",
-    "disableForce"     : false,
-    "closeReloadPage"  : true,
-    "contextMenu"      : true,
-    "onlyMainFrame"    : true,
-    "ignoreQueryString": false,
-    "sitesOpenedBySelf": "",
-    "disableException" : false,
-    "logging"          : true,
-    "debug"            : false
+    "forceielist"       : "http://www.example.com/*",
+    "disableForce"      : false,
+    "closeReloadPage"   : true,
+    "contextMenu"       : true,
+    "onlyMainFrame"     : true,
+    "ignoreQueryString" : false,
+    "sitesOpenedBySelf" : "",
+    "disableException"  : false,
+    "logging"           : true,
+    "useBrowserSelector": false,
+    "debug"             : false
   }
 }

--- a/managed-storage/policies.json
+++ b/managed-storage/policies.json
@@ -3,16 +3,17 @@
     "3rdparty": {
       "Extensions": {
         "ieview-we@clear-code.com": {
-          "forceielist"      : "http://www.example.com/*",
-          "disableForce"     : false,
-          "closeReloadPage"  : true,
-          "contextMenu"      : true,
-          "onlyMainFrame"    : true,
-          "ignoreQueryString": false,
-          "sitesOpenedBySelf": "",
-          "disableException" : false,
-          "logging"          : true,
-          "debug"            : false
+          "forceielist"       : "http://www.example.com/*",
+          "disableForce"      : false,
+          "closeReloadPage"   : true,
+          "contextMenu"       : true,
+          "onlyMainFrame"     : true,
+          "ignoreQueryString" : false,
+          "sitesOpenedBySelf" : "",
+          "disableException"  : false,
+          "logging"           : true,
+          "useBrowserSelector": false,
+          "debug"             : false
         }
       }
     }


### PR DESCRIPTION
This adds a new mode that uses BrowserSelector as the host program,
instead of our host.go.

It's especially useful when we need a bidirectional link between IE and
Firefox. Since the URL pattern matching is done in BrowserSelector in
this mode, we no more need to maintain two separate copies of the URL
pattern definition.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>