### PR TITLE
Add Microsoft Edge support

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -22,5 +22,6 @@
   "config_debug_label":               { "message": "Print debug log" },
   "config_talkEnabled_label":         { "message": "Enable Talk client mode (Needs Restart)" },
   "config_talkServerName_label":      { "message": "Talk server to connect" },
-  "config_talkAlarmMinutes_label":    { "message": "Sync with Talk server for every N minutes（Chrome only）" }
+  "config_talkAlarmMinutes_label":    { "message": "Sync with Talk server for every N minutes (for Chrome/Edge)" },
+  "config_talkBrowserName_label":     { "message": "Choose the browser model (for Chrome/Edge)" }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -22,5 +22,6 @@
   "config_debug_label":               { "message": "デバッグログを出力" },
   "config_talkEnabled_label":         { "message": "Talkサーバーとの対話モードを有効化する（要再起動）" },
   "config_talkServerName_label":      { "message": "接続するTalkサーバー" },
-  "config_talkAlarmMinutes_label":    { "message": "TalkサーバーとN分ごとに設定を同期する（Chrome版のみ有効）" }
+  "config_talkAlarmMinutes_label":    { "message": "TalkサーバーとN分ごとに設定を同期する（Chrome/Edge版のみ有効）" },
+  "config_talkBrowserName_label":     { "message": "ブラウザ名を選択してください（Chrome/Edge版のみ有効）" }
 }

--- a/background.js
+++ b/background.js
@@ -194,7 +194,8 @@ var ChromeTalkClient = {
 
   configure: function() {
     var server = configs.talkServerName;
-    var query = new String('C chrome');
+    var browser = configs.talkBrowserName;
+    var query = new String('C ' + browser);
 
     chrome.runtime.sendNativeMessage(server, query, (resp) => {
       this.cached = resp.config;
@@ -253,7 +254,8 @@ var ChromeTalkClient = {
 
   redirect: function(bs, details) {
     var server = configs.talkServerName;
-    var query = new String('Q chrome ' + details.url);
+    var browser = configs.talkBrowserName;
+    var query = new String('Q ' + browser + ' ' + details.url);
 
     if (details.tabId < 0) {
         return;
@@ -278,6 +280,7 @@ var ChromeTalkClient = {
   onBeforeRequest: function(details) {
     var bs = this.cached;
     var host = details.url.split('/')[2];
+    var browser = configs.talkBrowserName;
 
     if (!bs) {
       log('[Talk] config cache is empty. Fetching...');
@@ -292,9 +295,9 @@ var ChromeTalkClient = {
 
       if (this.regex(pattern, bs).test(details.url)) {
         debug('[Talk] Match', {pattern: pattern, url: details.url, browser: browser})
-        if (browser == 'chrome')
+        if (browser == browser)
           return;
-        if (browser == '' && bs.SecondBrowser == 'chrome')
+        if (browser == '' && bs.SecondBrowser == browser)
           return;
         return this.redirect(bs, details);
       }
@@ -307,9 +310,9 @@ var ChromeTalkClient = {
 
       if (this.regex(pattern, bs).test(host)) {
         debug('[Talk] Match', {pattern: pattern, host: host, browser: browser})
-        if (browser == 'chrome')
+        if (browser == browser)
           return;
-        if (browser == '' && bs.SecondBrowser == 'chrome')
+        if (browser == '' && bs.SecondBrowser == browser)
           return;
         return this.redirect(bs, details);
       }
@@ -317,7 +320,7 @@ var ChromeTalkClient = {
 
     /* No pattern matched */
     debug('[Talk] No pattern matched', {url: details.url})
-    if (bs.DefaultBrowser !== 'chrome') {
+    if (bs.DefaultBrowser !== browser) {
       return this.redirect(bs, details);
     }
   }

--- a/common/common.js
+++ b/common/common.js
@@ -40,5 +40,6 @@ configs = new Configs({
 	talkEnabled      : false,
 	talkServerName   : 'com.clear_code.browserselector_talk',
 	talkAlarmMinutes : 1,
+	talkBrowserName  : "chrome",
 	debug            : false
 });

--- a/options/options.html
+++ b/options/options.html
@@ -12,6 +12,9 @@
     <script type="application/javascript" src="/extlib/l10n.js"></script>
     <script type="application/javascript" src="/options/init.js"></script>
   </head>
+  <style>
+    .box {padding:0.5em;border:1px dashed #999;background:#f7f7f7;}
+  </style>
   <body>
     <p><label>__MSG_config_ieapp_label_before__
          <input id="ieapp"
@@ -59,6 +62,8 @@
     <p><label><input id="debug"
                      type="checkbox">
              __MSG_config_debug_label__</label></p>
+
+    <div class='box'>
     <p><label><input id="talkEnabled"
                      type="checkbox">
              __MSG_config_talkEnabled_label__</label></p>
@@ -68,5 +73,11 @@
                  size="30"></label></p>
     <p><label>__MSG_config_talkAlarmMinutes_label__
               <input id="talkAlarmMinutes" type="number" min="1"></label></p>
+    <p><label>__MSG_config_talkBrowserName_label__
+              <select id="talkBrowserName">
+                <option value='chrome'>Google Chrome</option>
+                <option value='edge'>Microsoft Edge</option>
+              </select>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
With this patch, we can use IEView WE on Microsoft Edge in combination
with BrowserSelector.

I added a new option 'talkBrowserName' in order to detect the browser
model (i.e. Edge vs Chrome). This option might be usable to support
other Chrome-based browsers like Opera as well.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>