### PR TITLE
Add template for reporting bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,66 @@
+name: Bug Report
+description: Create a report with a procedure for reproducing the bug
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: To Reproduce
+      description: Steps to reproduce the behavior
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Your Environment
+      description: |
+        - Firefox version:
+        - IE View WE addon version: See about:addons.
+
+        Tip: If you hit the problem with older IE View WE version, try latest version first.
+      value: |
+        - Firefox version:
+        - IE View WE Firefox addon version:
+      render: markdown
+    validations:
+      required: true
+  - type: textarea
+    id: configuration
+    attributes:
+      label: Your Configuration
+      description: |
+        Write your IE View WE configuration. Minimum reproducible one is recommended.
+      value: |
+        - Force IE list:
+        - Sites opened by self:
+      render: markdown
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Your debug log
+      description: Write your debug log here
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    id: addtional-context
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a vulnerability
+    url: https://github.com/clear-code/ieview-we/security/policy
+    about: For reporting a vulnerability, please refer our Security Policy here: https://github.com/clear-code/ieview-we/security/policy

--- a/.github/ISSUE_TEMPLATE/release_task.yaml
+++ b/.github/ISSUE_TEMPLATE/release_task.yaml
@@ -1,0 +1,60 @@
+name: Issue for new release
+title: "Release: x.y.z"
+description: Create a issue for a new release
+body:
+  - type: markdown
+    id: description
+    attributes:
+      value: |
+        This is a issue for new release x.y.z
+  - type: checkboxes
+    id: create-new-tag
+    attributes:
+      label: Create a new tag
+      description: Tag a new version for planned release
+      options:
+        - label: New tag has been created!
+          required: false
+  - type: checkboxes
+    id: create-release-notes
+    attributes:
+      label: Create release note
+      description: Add release note as pre-release.
+      options:
+        - label: Release note has been created!
+          required: false
+  - type: checkboxes
+    id: build-assets
+    attributes:
+      label: Create new assets for release
+      description: |
+        Build binary files to upload.
+        See https://github.com/clear-code/ieview-we#how-to-build-the-native-messaging-host-and-its-installer
+      options:
+        - label: Asset files has been built!
+          required: false
+  - type: checkboxes
+    id: test-assets
+    attributes:
+      label: Test assets for release
+      description: |
+        Test prebuilt binary files whether it is production ready.
+        Described issues in release note should be tested.
+      options:
+        - label: Asset files has been attached!
+          required: false
+  - type: checkboxes
+    id: publish-release-notes
+    attributes:
+      label: Publish release notes
+      description: If it is ready to ship, publish the release note!
+      options:
+        - label: Release note has been published
+          required: false
+  - type: textarea
+    id: addtional-context
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.
+    validations:
+      required: false


### PR DESCRIPTION
This PR is followup PR of #50, #51, #52.

Here is the screenshot of this PR.


![image](https://user-images.githubusercontent.com/225841/207496354-1e2910cd-40ee-462a-a07a-0733e758a2c0.png)

Added bug report, release issue, and security report contact.

After selecting bug report, you can fill in forms:

![image](https://user-images.githubusercontent.com/225841/206972203-4901f1cf-f999-4e47-834c-4386b480571f.png)

After selecting release issue, you can fill in forms:

![image](https://user-images.githubusercontent.com/225841/207496610-17eb38ba-9447-42ac-bad9-67f481720e98.png)

After selecting view policy, guided to security policy page:

![image](https://user-images.githubusercontent.com/225841/207496657-c45908ef-e800-4008-b14f-81e962b0a739.png)
