### PR TITLE
Add development guideline

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,27 @@
+# Development Guidelines
+
+* Branch guidelines
+* Issue guidelines
+* Release guidelines
+
+## Branch guidelines
+
+* Use master branch as stable branch
+* Use topic branch to implement new features
+* Don't directly commit to master branch
+
+## Issue and Pull request guidelines
+
+* Create new issue before implement new features
+  * Discuss and review specification beforehand
+* Create new pull request corresponding to existing issue
+* Each pull request must be reviewed
+* Assign bug, enhancement or breaking-change label to pull request
+
+## Release guidelines
+
+* Create a new tag vX.Y.Z (such as v1.6.6)
+* Create new issue for release
+* Create new release via https://github.com/clear-code/ieview-we/releases/new
+* Test assets for release
+* Publish release note


### PR DESCRIPTION
There is a explanation how to build, [1] but not for development guideline.
So it is aimed to add our guideline here.


[1] https://github.com/clear-code/ieview-we#how-to-build-the-native-messaging-host-and-its-installer