### PR TITLE
Fallback to self if default browser is not configured on ThinBridge

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -532,18 +532,20 @@ const ThinBridgeTalkClient = {
     }
     console.log(`* Check patterns for ${url}`);
 
-    const URLExcludePatterns = tbconfig.URLExcludePatterns || tbconfig.Excludes;
-    for (let i = 0; i < URLExcludePatterns.length; i++) {
-      if (wildcmp(URLExcludePatterns[i][0], url)) {
-        console.log(`* Match Exclude [${URLExcludePatterns[i][0]}]`)
+    for (let pattern of (tbconfig.URLExcludePatterns || tbconfig.Excludes)) {
+      if (Array.isArray(pattern))
+        pattern = pattern[0];
+      if (wildcmp(pattern, url)) {
+        console.log(`* Match Exclude [${pattern}]`)
         return false;
       }
     }
 
-    const URLPatterns = tbconfig.URLPatterns || tbconfig.Patterns;
-    for (let i = 0; i < URLPatterns.length; i++) {
-      if (wildcmp(URLPatterns[i][0], url)) {
-        console.log(`* Match [${URLPatterns[i][0]}]`)
+    for (let pattern of (tbconfig.URLPatterns || tbconfig.Patterns)) {
+      if (Array.isArray(pattern))
+        pattern = pattern[0];
+      if (wildcmp(pattern, url)) {
+        console.log(`* Match [${pattern}]`)
         return true;
       }
     }
@@ -557,18 +559,20 @@ const ThinBridgeTalkClient = {
     }
     console.log(`* Check patterns for ${url}`);
 
-    const URLExcludePatterns = tbconfig.URLExcludePatterns || tbconfig.Excludes;
-    for (let i = 0; i < URLExcludePatterns.length; i++) {
-      if (wildcmp(URLExcludePatterns[i][0], url)) {
-        console.log(`* Match Exclude [${URLExcludePatterns[i][0]}]`)
+    for (let pattern of (tbconfig.URLExcludePatterns || tbconfig.Excludes)) {
+      if (Array.isArray(pattern))
+        pattern = pattern[0];
+      if (wildcmp(pattern, url)) {
+        console.log(`* Match Exclude [${pattern}]`)
         return true;
       }
     }
 
-    const URLPatterns = tbconfig.URLPatterns || tbconfig.Patterns;
-    for (let i = 0; i < URLPatterns.length; i++) {
-      if (wildcmp(URLPatterns[i][0], url)) {
-        console.log(`* Match [${URLPatterns[i][0]}]`)
+    for (let pattern of (tbconfig.URLPatterns || tbconfig.Patterns)) {
+      if (Array.isArray(pattern))
+        pattern = pattern[0];
+      if (wildcmp(pattern, url)) {
+        console.log(`* Match [${pattern}]`)
         return false;
       }
     }

--- a/background/background.js
+++ b/background/background.js
@@ -532,16 +532,18 @@ const ThinBridgeTalkClient = {
     }
     console.log(`* Check patterns for ${url}`);
 
-    for (let i = 0; i < tbconfig.URLExcludePatterns.length; i++) {
-      if (wildcmp(tbconfig.URLExcludePatterns[i][0], url)) {
-        console.log(`* Match Exclude [${tbconfig.URLExcludePatterns[i][0]}]`)
+    const URLExcludePatterns = tbconfig.URLExcludePatterns || tbconfig.Excludes;
+    for (let i = 0; i < URLExcludePatterns.length; i++) {
+      if (wildcmp(URLExcludePatterns[i][0], url)) {
+        console.log(`* Match Exclude [${URLExcludePatterns[i][0]}]`)
         return false;
       }
     }
 
-    for (let i = 0; i < tbconfig.URLPatterns.length; i++) {
-      if (wildcmp(tbconfig.URLPatterns[i][0], url)) {
-        console.log(`* Match [${tbconfig.URLPatterns[i][0]}]`)
+    const URLPatterns = tbconfig.URLPatterns || tbconfig.Patterns;
+    for (let i = 0; i < URLPatterns.length; i++) {
+      if (wildcmp(URLPatterns[i][0], url)) {
+        console.log(`* Match [${URLPatterns[i][0]}]`)
         return true;
       }
     }
@@ -555,16 +557,18 @@ const ThinBridgeTalkClient = {
     }
     console.log(`* Check patterns for ${url}`);
 
-    for (let i = 0; i < tbconfig.URLExcludePatterns.length; i++) {
-      if (wildcmp(tbconfig.URLExcludePatterns[i][0], url)) {
-        console.log(`* Match Exclude [${tbconfig.URLExcludePatterns[i][0]}]`)
+    const URLExcludePatterns = tbconfig.URLExcludePatterns || tbconfig.Excludes;
+    for (let i = 0; i < URLExcludePatterns.length; i++) {
+      if (wildcmp(URLExcludePatterns[i][0], url)) {
+        console.log(`* Match Exclude [${URLExcludePatterns[i][0]}]`)
         return true;
       }
     }
 
-    for (let i = 0; i < tbconfig.URLPatterns.length; i++) {
-      if (wildcmp(tbconfig.URLPatterns[i][0], url)) {
-        console.log(`* Match [${tbconfig.URLPatterns[i][0]}]`)
+    const URLPatterns = tbconfig.URLPatterns || tbconfig.Patterns;
+    for (let i = 0; i < URLPatterns.length; i++) {
+      if (wildcmp(URLPatterns[i][0], url)) {
+        console.log(`* Match [${URLPatterns[i][0]}]`)
         return false;
       }
     }

--- a/background/background.js
+++ b/background/background.js
@@ -645,6 +645,19 @@ const ThinBridgeTalkClient = {
         }
       }
 
+      if (redirectCount == 0) {
+        console.log(`* No redirection: fallback to default`);
+        if (tbconfig.DefaultBrowser == '' ||
+            String(tbconfig.DefaultBrowser).toLowerCase() == BROWSER.toLowerCase()) {
+          console.log(`* Continue to load as the default reaction`);
+          loadCount++;
+        }
+        else {
+          console.log(`* Redirect to the default browser ${tbconfig.DefaultBrowser}`);
+          redirectCount++;
+        }
+      }
+
       if (redirectCount > 0 || loadCount == 0) {
         console.log(`* Redirect to another browser`);
         this.redirect(url, tabId, closeTabCount > 0);

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "__MSG_extensionDescription__",
   "permissions": [
     "contextMenus",


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

This corresponds to the change on ThinBridge.
See also: https://github.com/ThinBridge/ThinBridge/pull/49

# How to verify the fixed issue:

Configure redirection rules and no default browser, and try loading URL which should not match any rule.

## The steps to verify:

1. Install ThinBridge (64bit version) from the installer.
2. Configure `C:\Program Files\ThinBridge\ThinBridgeBHO.ini` as following:
   ```
   [GLOBAL]
   @DISABLED
   @TOP_PAGE_ONLY
   @INTRANET_ZONE
   @TRUSTED_ZONE
   @UNTRUSTED_ZONE
   @RDP_APPMODE
   
   [Edge]
   @BROWSER_PATH:
   @TOP_PAGE_ONLY
   @REDIRECT_PAGE_ACTION:0
   @CLOSE_TIMEOUT:1
   *
   -http://localhost*
   -https://localhost*
      
   [Default]
   @BROWSER_PATH:
   @TOP_PAGE_ONLY
   @REDIRECT_PAGE_ACTION:0
   @CLOSE_TIMEOUT:3
   ```
3. Build CRX for Chrome. (`make chrome`)
4. Install the built CRX to Chrome as a managed extension. See instructions (for BrowserSelector): https://gitlab.com/clear-code/browserselector#notes-for-manifest-v3
5. Add the ID of the built CRX to the file: `C:\Program Files\ThinBridge\ThinBridgeHost\chrome.json`
6. Start Chrome.
7. Configure IE View WE to use ThinBridge.
8. Restart Chrome.
9. Try to load https://example.com/
10. Try to load https://localhost/

## Expected result:

* https://example.com/ is redirected to Edge.
* https://localhost/ is loaded by Chrome.
